### PR TITLE
Add `source.clojure.clojurescript`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -6,7 +6,7 @@ class ClojureKondoLinter(Linter):
   regex = r'^(?P<path>\S+):(?P<line>\d+):(?P<col>\d+): (?:(?P<warning>warning)|(?P<error>error)): (?P<message>.*)'
   multiline = False
   defaults = {
-    'selector': 'source.clojure',
+    'selector': 'source.clojure - source.clojure.clojurescript',
   }
   cmd = ['clj-kondo', '--lang', 'clj', '--lint', '-']
   word_re = r'^([^][)(\s]+)'
@@ -16,7 +16,7 @@ class ClojureScriptKondoLinter(Linter):
   regex = r'^(?P<path>\S+):(?P<line>\d+):(?P<col>\d+): (?:(?P<warning>warning)|(?P<error>error)): (?P<message>.*)'
   multiline = False
   defaults = {
-    'selector': 'source.clojurescript',
+    'selector': 'source.clojurescript, source.clojure.clojurescript',
   }
   cmd = ['clj-kondo', '--lang', 'cljs', '--lint', '-']
   word_re = r'^([^][)(\s]+)'


### PR DESCRIPTION
Might close #1. At least a part of it. As currently implemented (and using the proposed change to the official ST Clojure/ClojureScript syntax), both linters get run on ClojureScript so this is a definite WIP, but I didn't want to lose it.